### PR TITLE
fix infinite recursion issue

### DIFF
--- a/src/benchy.nim
+++ b/src/benchy.nim
@@ -72,7 +72,7 @@ template timeIt*(tag: string, iterations: untyped, body: untyped) =
     deltas: seq[float64]
 
   block:
-    proc test() =
+    proc test() {.gensym.} =
       body
 
     while true:


### PR DESCRIPTION
When the name of the function to be benchmarked happens to be `test`, the program will fall into an infinite loop.
The sample code is as follows:
```nim
import benchy

proc test() =
    # some code to be benchmarked...
    discard

timeIt "test function":
    test()
```